### PR TITLE
fix for PEP-8 and also usage of pathlib.Path

### DIFF
--- a/external/setup_dependencies_vkw.py
+++ b/external/setup_dependencies_vkw.py
@@ -1,30 +1,25 @@
-import os
-from shutil import copyfile
+from os import environ, name as os_name
+from pathlib import Path
+# from shutil import copyfile  # not used yet
 from subprocess import call
+
 
 def create_paths_if_invalid(*paths):
     for path in paths:
-        if not os.path.exists(path):
-            os.mkdir(path)
+        path = Path(path)  # seems expensive, but time seems not as crucial here and it's used when os is not Win anyway
+        if not path.exists():
+            path.mkdir()
 
 
-dirname = os.path.dirname(__file__)
-proj_path_vulkan = os.path.join(dirname, 'Vulkan')
+if __name__ == '__main__':
+    dirname = Path(__file__).resolve().parent  # same as dirname
+    proj_path_vulkan = dirname / 'Vulkan'  # Path overrides __floordiv__, so joining works with slashes
 
-if os.name == 'nt':
-    os_path_vulkan = os.environ['VULKAN_SDK']
-    call(['robocopy', os.path.join(os_path_vulkan, "include"), os.path.join(proj_path_vulkan, "include"), "/E"])
-    call(['robocopy', os.path.join(os_path_vulkan, "Lib"), os.path.join(proj_path_vulkan, "lib64"), "/E"])
-    call(['robocopy', os.path.join(os_path_vulkan, "Lib32"), os.path.join(proj_path_vulkan, "lib32"), "/E"])
-else:
-    create_paths_if_invalid(proj_path_vulkan)
-    print("Not working for any other OS other than Windows")
-
-
-
-
-
-
-
-
-
+    if os_name == 'nt':
+        os_path_vulkan = Path(environ['VULKAN_SDK'])
+        call(['robocopy', os_path_vulkan / 'include', proj_path_vulkan / 'include', '/E'])
+        call(['robocopy', os_path_vulkan / 'Lib', proj_path_vulkan / 'lib64', '/E'])
+        call(['robocopy', os_path_vulkan / 'Lib32', proj_path_vulkan / 'lib32', '/E'])
+    else:
+        create_paths_if_invalid(proj_path_vulkan)
+        print('Not working for any other OS other than Windows')


### PR DESCRIPTION
PEP-8 fixes (mostly blank line stuff) and [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html) which is considered a cleaner way to deal with paths while even supporting several types of path strings (like `\` or `//` separators)